### PR TITLE
Re-order filters

### DIFF
--- a/lib/enums/filters_enum.dart
+++ b/lib/enums/filters_enum.dart
@@ -1,8 +1,8 @@
 enum FiltersEnum {
   hidden,
+  one_week_old,
   day_of_week,
   period_of_day,
-  all_pings,
-  one_week_old,
-  resonated
+  resonated,
+  all_pings
 }

--- a/lib/extensions/filters_enum_extensions.dart
+++ b/lib/extensions/filters_enum_extensions.dart
@@ -15,18 +15,18 @@ extension StringParsing on FiltersEnum {
   String title() {
     final time = DateTime.now();
     switch (this) {
-      case FiltersEnum.all_pings:
-        return "all pings";
-      case FiltersEnum.resonated:
-        return "re-pings";
-      case FiltersEnum.period_of_day:
-        return "${time.themeMode().title()}s";
-      case FiltersEnum.day_of_week:
-        return "${time.dayOfWeek().title()}s";
-      case FiltersEnum.one_week_old:
-        return "last week";
       case FiltersEnum.hidden:
         return "hidden";
+      case FiltersEnum.one_week_old:
+        return "last week";
+      case FiltersEnum.day_of_week:
+        return "${time.dayOfWeek().title()}s";
+      case FiltersEnum.period_of_day:
+        return "${time.themeMode().title()}s";
+      case FiltersEnum.resonated:
+        return "re-pings";
+      case FiltersEnum.all_pings:
+        return "all pings";
     }
   }
 }
@@ -35,22 +35,22 @@ extension WidgetParsing on FiltersEnum {
   Widget page() {
     final time = DateTime.now();
     switch (this) {
-      case FiltersEnum.all_pings:
-        return BrowseAllPage();
-      case FiltersEnum.resonated:
-        return BrowseResonatedPingsPage();
-      case FiltersEnum.period_of_day:
-        final mode = time.themeMode();
-        return BrowseModePage(mode: mode.toString().split('.').last);
+      case FiltersEnum.hidden:
+        return BrowseHiddenPage();
+      case FiltersEnum.one_week_old:
+        return BrowseLastWeekPage();
       case FiltersEnum.day_of_week:
         return BrowseTimePage(
           timeEnum: TimeFilterEnum.dayOfWeek,
           time: time,
         );
-      case FiltersEnum.one_week_old:
-        return BrowseLastWeekPage();
-      case FiltersEnum.hidden:
-        return BrowseHiddenPage();
+      case FiltersEnum.period_of_day:
+        final mode = time.themeMode();
+        return BrowseModePage(mode: mode.toString().split('.').last);
+      case FiltersEnum.resonated:
+        return BrowseResonatedPingsPage();
+      case FiltersEnum.all_pings:
+        return BrowseAllPage();
     }
   }
 }

--- a/lib/providers/homepage_filters_provider.dart
+++ b/lib/providers/homepage_filters_provider.dart
@@ -9,26 +9,17 @@ part 'homepage_filters_provider.g.dart';
 
 @riverpod
 Future<List<FiltersEnum>> homepageFilters(Ref ref) async {
-  final List<FiltersEnum> filters = [
-    FiltersEnum.hidden,
-    FiltersEnum.day_of_week,
-    FiltersEnum.period_of_day,
-    FiltersEnum.all_pings
-  ];
-
   final resonated = ref.watch(anyResonatedProvider);
   final lastWeek = ref.watch(anyLastWeekProvider);
 
-  if (resonated) {
-    filters.add(FiltersEnum.resonated);
-  }
-
-  if (lastWeek) {
-    filters.insert(
-      1,
-      FiltersEnum.one_week_old,
-    );
-  }
+  final List<FiltersEnum> filters = [
+    FiltersEnum.hidden,
+    if (lastWeek) FiltersEnum.one_week_old,
+    FiltersEnum.day_of_week,
+    FiltersEnum.period_of_day,
+    if (resonated) FiltersEnum.resonated,
+    FiltersEnum.all_pings
+  ];
 
   return filters;
 }


### PR DESCRIPTION
### Goal
Re-order the filters so that the default (the furthest right for the user) is "all pings" instead of the conditional "re-pings" view.

### Changes
- `homepage_filters_provider.dart`: re-ordered the filter list; changed how the list is being built conditionally
- `filters_enum_extensions.dart`: updated order (tidying)
- `filters_enum.dart`: updated order (tidying)

### Screenshots + Recordings
| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/8a84aff5-2b7f-4464-bad3-941f08959880" controls width="400"></video> | <video src="https://github.com/user-attachments/assets/27d3e5f8-d6f9-4134-bf45-b6f2cd6397e7" controls width="400"></video> |