### PR TITLE
Fix search scroll position bug

### DIFF
--- a/lib/components/ping_grid.dart
+++ b/lib/components/ping_grid.dart
@@ -7,10 +7,13 @@ class PingGrid extends StatelessWidget {
     super.key,
     required this.pings,
     this.sortByResonance = false,
+    required this.shouldRetainScrollPosition
   });
 
   final List<PingData> pings;
   final bool sortByResonance;
+  final bool shouldRetainScrollPosition;
+
   @override
   Widget build(BuildContext context) {
     return NotificationListener<ScrollNotification>(
@@ -24,6 +27,7 @@ class PingGrid extends StatelessWidget {
         child: SystemGrid(
           pings: pings,
           sortByResonance: sortByResonance,
+          shouldRetainScrollPosition: shouldRetainScrollPosition,
         ));
   }
 }

--- a/lib/components/ping_search_list.dart
+++ b/lib/components/ping_search_list.dart
@@ -12,7 +12,7 @@ class PingSearchList extends ConsumerWidget {
     final pings = ref.watch(searchProvider);
 
     return switch (pings) {
-      AsyncData(value: final pingsValue) => PingGrid(pings: pingsValue),
+      AsyncData(value: final pingsValue) => PingGrid(pings: pingsValue, shouldRetainScrollPosition: true),
       AsyncError() => SystemText(text: "Error"),
       _ => SizedBox.shrink()
     };

--- a/lib/design_system/system_grid.dart
+++ b/lib/design_system/system_grid.dart
@@ -27,10 +27,12 @@ class SystemGrid extends StatelessWidget {
     super.key,
     required this.pings,
     this.sortByResonance = false,
+    required this.shouldRetainScrollPosition
   });
 
   final List<PingData> pings;
   final bool sortByResonance;
+  final bool shouldRetainScrollPosition;
 
   @override
   Widget build(BuildContext context) {
@@ -38,6 +40,7 @@ class SystemGrid extends StatelessWidget {
     List<DateGroup> dateGroups = _groupPingsByDate(pings);
 
     return CustomScrollView(
+      key: shouldRetainScrollPosition ? PageStorageKey<String>('ping_search_grid') : null,
       slivers: [
         // Add top padding of 100px
         SliverToBoxAdapter(

--- a/lib/pages/browse_page.dart
+++ b/lib/pages/browse_page.dart
@@ -43,6 +43,7 @@ class BrowsePage extends ConsumerWidget {
                 child: PingGrid(
                   pings: pings,
                   sortByResonance: sortByResonance,
+                  shouldRetainScrollPosition: false,
                 ));
   }
 }


### PR DESCRIPTION
### Goal
Address the [following bug](https://youtube.com/shorts/K837OIs05B4):

> When a user 1) searches, 2) clicks on a search result, and 3) returns to search list, they are automatically "scrolled" back to the top (most recently created) search results, instead of where they left off.

### Changes

- `system_grid.dart`: Defines a scrollable grid view of Pings.  I added a flag, `shouldRetainScrollPosition`, that allows us to  specify whether we want to use a PageStorageKey to set (and preserve) our scroll position.
- `ping_grid.dart`: A wrapper that creates a `SystemGrid` of Pings.  For our purposes here, an intermediary that passes the flag between the creators of the view (below) and its actual instantiation (above).
- `browse_page.dart`: Used in all the browse pages, where we don't want to preserve scroll position across switches.
- `ping_search_list.dart`: Used for the search result list, where we _do_ want to preserve scroll position!


### Screenshots + Recordings

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/c73bb01d-05a3-4b42-826f-4b66a121ddda" controls width="400"></video> | <video src="https://github.com/user-attachments/assets/43758ff6-a35e-4879-b392-a847815cc874" controls width="400"></video> |





