### PR TITLE
Initial custom lenses

### DIFF
--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,2 +1,1 @@
-Testing out the build notes functionality!
-This build and the previous one are both dev test builds; no new features... yet!
+Rough initial version of the custom lens experience for design iteration.

--- a/lib/components/clear_saved_searches_cell.dart
+++ b/lib/components/clear_saved_searches_cell.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/components/settings_activation_cell.dart';
+import 'package:practice/providers/simple_saved_searches_provider.dart';
+
+class ClearSavedSearchesCell extends ConsumerWidget {
+  const ClearSavedSearchesCell({super.key});
+
+  void _showSnackBar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        elevation: 0,
+        content: Text(
+          message,
+          style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  Future<void> _showClearConfirmation(BuildContext context, WidgetRef ref) async {
+    final savedSearches = await ref.read(simpleSavedSearchesProvider.future);
+    
+    if (savedSearches.isEmpty) {
+      if (context.mounted) {
+        _showSnackBar(context, 'No saved searches to clear');
+      }
+      return;
+    }
+
+if (context.mounted) {
+      final count = savedSearches.length;
+      final searchText = count == 1 ? '1 saved search' : 'all $count saved searches';
+      
+      final shouldClear = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Clear Saved Searches'),
+          content: Text('Are you sure you want to delete $searchText?  This cannot be undone.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              style: TextButton.styleFrom(
+                foregroundColor: const Color.fromARGB(255, 158, 39, 25),
+                textStyle: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
+      );
+
+      if (shouldClear == true) {
+        try {
+          await ref.read(simpleSavedSearchesProvider.notifier).clearAllSavedSearches();
+          if (context.mounted) {
+            _showSnackBar(context, 'Saved searches cleared');
+          }
+        } catch (e) {
+          if (context.mounted) {
+            _showSnackBar(context, 'Failed to clear saved searches');
+          }
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SettingsActivationCell(
+      text: "Clear All Saved Searches",
+      onTap: () => _showClearConfirmation(context, ref),
+    );
+  }
+}

--- a/lib/components/search_text_field.dart
+++ b/lib/components/search_text_field.dart
@@ -4,6 +4,8 @@ import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/constants.dart';
 import 'package:practice/providers/search_string_provider.dart';
+import 'package:practice/providers/search_provider.dart';
+import 'package:practice/providers/simple_saved_searches_provider.dart';
 
 class SearchTextField extends ConsumerStatefulWidget {
   const SearchTextField({super.key});
@@ -15,44 +17,113 @@ class SearchTextField extends ConsumerStatefulWidget {
 class _PingEntryState extends ConsumerState<SearchTextField> {
   final controller = TextEditingController();
   final focusNode = FocusNode();
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        elevation: 0,
+        content: Text(
+          message,
+          style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        duration: const Duration(seconds: 2),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  Future<void> _saveCurrentSearch() async {
+    final currentText = controller.text.trim();
+    if (currentText.isEmpty) return;
+
+    try {
+      final wasAdded = await ref.read(simpleSavedSearchesProvider.notifier).addSavedSearch(currentText);
+      
+      if (mounted) {
+        if (wasAdded) {
+          _showSnackBar('Search "$currentText" saved!');
+        } else {
+          _showSnackBar('Search "$currentText" already exists');
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        _showSnackBar('Failed to save search');
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final searchString = ref.watch(searchStringProvider);
+    final searchResults = ref.watch(searchProvider);
+    
+    final showPlusButton = searchResults.when(
+      data: (pings) => pings.length > 3,
+      loading: () => false,
+      error: (_, __) => false,
+    );
 
-    return TextField(
-      focusNode: focusNode,
-      autofocus: true,
-      controller: controller,
-      decoration: InputDecoration(
-        hintText: 'Search',
-        hintStyle: TextStyle(
-          color: Theme.of(context).colorScheme.onSurface,
-        ),
-        prefixIcon: Icon(
-          PhosphorIcons.magnifying_glass,
-          color: Theme.of(context).colorScheme.secondary,
-        ),
-        suffixIcon: searchString.isEmpty
-            ? null
-            : IconButton(
-                icon: Icon(PhosphorIcons.x_circle_fill,
-                    color: Theme.of(context).colorScheme.secondary),
-                onPressed: () {
-                  HapticFeedback.selectionClick();
-                  ref.read(searchStringProvider.notifier).setSearch('');
-                  controller.clear();
-                  focusNode.requestFocus();
-                },
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            focusNode: focusNode,
+            autofocus: true,
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: 'Search',
+              hintStyle: TextStyle(
+                color: Theme.of(context).colorScheme.onSurface,
               ),
-        filled: true,
-        fillColor: Theme.of(context).colorScheme.surface,
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(spacingFour),
-          borderSide: BorderSide.none,
+              prefixIcon: Icon(
+                PhosphorIcons.magnifying_glass,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+              suffixIcon: searchString.isEmpty
+                  ? null
+                  : IconButton(
+                      icon: Icon(PhosphorIcons.x_circle_fill,
+                          color: Theme.of(context).colorScheme.secondary),
+                      onPressed: () {
+                        HapticFeedback.selectionClick();
+                        ref.read(searchStringProvider.notifier).setSearch('');
+                        controller.clear();
+                        focusNode.requestFocus();
+                      },
+                    ),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(spacingFour),
+                borderSide: BorderSide.none,
+              ),
+            ),
+            onChanged: (value) =>
+                ref.read(searchStringProvider.notifier).setSearch(value),
+          ),
         ),
-      ),
-      onChanged: (value) =>
-          ref.read(searchStringProvider.notifier).setSearch(value),
+        if (showPlusButton) ...[
+          SizedBox(width: spacingSmall),
+          GestureDetector(
+            onTap: _saveCurrentSearch,
+            child: Container(
+              height: 48,
+              width: 48,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+                borderRadius: BorderRadius.circular(spacingFour),
+              ),
+              child: Icon(
+                PhosphorIcons.plus,
+                color: Theme.of(context).colorScheme.onPrimary,
+                size: 20,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/enums/filters_enum.dart
+++ b/lib/enums/filters_enum.dart
@@ -4,5 +4,16 @@ enum FiltersEnum {
   day_of_week,
   period_of_day,
   resonated,
-  all_pings
+  all_pings,
+  saved_search,
+}
+
+class LensItem {
+  final FiltersEnum filter;
+  final String? savedSearchQuery;
+
+  const LensItem.filter(this.filter) : savedSearchQuery = null;
+  const LensItem.savedSearch(this.savedSearchQuery) : filter = FiltersEnum.saved_search;
+
+  bool get isSavedSearch => filter == FiltersEnum.saved_search;
 }

--- a/lib/extensions/filters_enum_extensions.dart
+++ b/lib/extensions/filters_enum_extensions.dart
@@ -10,6 +10,7 @@ import 'package:practice/pages/browse_last_week_page.dart';
 import 'package:practice/pages/browse_mode_page.dart';
 import 'package:practice/pages/browse_resonated_pings.dart';
 import 'package:practice/pages/browse_time_page.dart';
+import 'package:practice/pages/browse_saved_search_page.dart';
 
 extension StringParsing on FiltersEnum {
   String title() {
@@ -27,6 +28,8 @@ extension StringParsing on FiltersEnum {
         return "re-pings";
       case FiltersEnum.all_pings:
         return "all pings";
+      case FiltersEnum.saved_search:
+        return "saved search";
     }
   }
 }
@@ -51,6 +54,24 @@ extension WidgetParsing on FiltersEnum {
         return BrowseResonatedPingsPage();
       case FiltersEnum.all_pings:
         return BrowseAllPage();
+      case FiltersEnum.saved_search:
+        return Container();
     }
+  }
+}
+
+extension LensItemExtensions on LensItem {
+  String title() {
+    if (isSavedSearch && savedSearchQuery != null) {
+      return '"$savedSearchQuery"';
+    }
+    return filter.title();
+  }
+
+  Widget page() {
+    if (isSavedSearch && savedSearchQuery != null) {
+      return BrowseSavedSearchPage(query: savedSearchQuery!);
+    }
+    return filter.page();
   }
 }

--- a/lib/pages/browse_saved_search_page.dart
+++ b/lib/pages/browse_saved_search_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/pages/browse_page.dart';
+import 'package:practice/providers/pings_map_provider.dart';
+
+class BrowseSavedSearchPage extends ConsumerWidget {
+  const BrowseSavedSearchPage({
+    super.key,
+    required this.query,
+  });
+
+  final String query;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pingsMapAsync = ref.watch(pingsMapProvider);
+    
+    return switch (pingsMapAsync) {
+      AsyncData(value: final pingsMap) => () {
+        final visiblePings = pingsMap.values.where((ping) => !ping.hidden);
+        final filteredPings = visiblePings
+            .where((ping) => ping.text.toLowerCase().contains(query.toLowerCase()))
+            .toList()
+          ..sort((a, b) => b.time.compareTo(a.time));
+        
+        return BrowsePage(pings: filteredPings);
+      }(),
+      AsyncError() => const BrowsePage(pings: []),
+      _ => const BrowsePage(pings: []),
+    };
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/components/browse_activation_cell.dart';
 import 'package:practice/components/cloud_backup_activation_cell.dart';
+import 'package:practice/components/clear_saved_searches_cell.dart';
 import 'package:practice/components/import_pings_button.dart';
 import 'package:practice/components/local_backup_activation_cell.dart';
 import 'package:practice/components/main_spacing_cell.dart';
@@ -33,6 +34,12 @@ class SettingsPage extends ConsumerWidget {
                     bottomPadding: false,
                     child: Column(
                       children: [
+                        NavCellCluster(text: 'Dev Settings', children: [
+                          ClearSavedSearchesCell(),
+                        ]),
+                        SizedBox(
+                          height: spacingMedium,
+                        ),
                         NavCellCluster(text: 'Feel', children: [
                           ThemePicker(),
                         ]),

--- a/lib/providers/homepage_filters_provider.dart
+++ b/lib/providers/homepage_filters_provider.dart
@@ -3,22 +3,25 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/enums/filters_enum.dart';
 import 'package:practice/providers/derived_pings_providers.dart';
+import 'package:practice/providers/simple_saved_searches_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'homepage_filters_provider.g.dart';
 
 @riverpod
-Future<List<FiltersEnum>> homepageFilters(Ref ref) async {
+Future<List<LensItem>> homepageFilters(Ref ref) async {
   final resonated = ref.watch(anyResonatedProvider);
   final lastWeek = ref.watch(anyLastWeekProvider);
+  final savedSearches = await ref.watch(simpleSavedSearchesProvider.future);
 
-  final List<FiltersEnum> filters = [
-    FiltersEnum.hidden,
-    if (lastWeek) FiltersEnum.one_week_old,
-    FiltersEnum.day_of_week,
-    FiltersEnum.period_of_day,
-    if (resonated) FiltersEnum.resonated,
-    FiltersEnum.all_pings
+  final List<LensItem> filters = [
+    LensItem.filter(FiltersEnum.hidden),
+    if (lastWeek) LensItem.filter(FiltersEnum.one_week_old),
+    LensItem.filter(FiltersEnum.day_of_week),
+    LensItem.filter(FiltersEnum.period_of_day),
+    if (resonated) LensItem.filter(FiltersEnum.resonated),
+    ...savedSearches.map((query) => LensItem.savedSearch(query)),
+    LensItem.filter(FiltersEnum.all_pings),
   ];
 
   return filters;

--- a/lib/providers/simple_saved_searches_provider.dart
+++ b/lib/providers/simple_saved_searches_provider.dart
@@ -1,0 +1,62 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'simple_saved_searches_provider.g.dart';
+
+@riverpod
+class SimpleSavedSearches extends _$SimpleSavedSearches {
+  static const String _storageKey = 'saved_searches_simple';
+
+  @override
+  Future<List<String>> build() async {
+    return await _loadSavedSearches();
+  }
+
+  Future<List<String>> _loadSavedSearches() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getStringList(_storageKey) ?? [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  Future<void> _saveSavedSearches(List<String> searches) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_storageKey, searches);
+  }
+
+  Future<bool> addSavedSearch(String query) async {
+    if (query.trim().isEmpty) return false;
+
+    final currentSearches = await future;
+    final trimmedQuery = query.trim();
+    
+    if (currentSearches.any((search) => 
+        search.toLowerCase() == trimmedQuery.toLowerCase())) {
+      return false;
+    }
+
+    final updatedSearches = [trimmedQuery, ...currentSearches];
+    await _saveSavedSearches(updatedSearches);
+    
+    state = AsyncData(updatedSearches);
+    return true;
+  }
+
+  Future<void> removeSavedSearch(String query) async {
+    final currentSearches = await future;
+    final updatedSearches = currentSearches
+        .where((search) => search != query)
+        .toList();
+    
+    await _saveSavedSearches(updatedSearches);
+    state = AsyncData(updatedSearches);
+  }
+
+  Future<void> clearAllSavedSearches() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_storageKey);
+    state = const AsyncData([]);
+  }
+}

--- a/lib/providers/simple_saved_searches_provider.g.dart
+++ b/lib/providers/simple_saved_searches_provider.g.dart
@@ -1,28 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'homepage_filters_provider.dart';
+part of 'simple_saved_searches_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$homepageFiltersHash() => r'7dd3c8dd3bcd5714ad80d8712fcbc9f58745aea2';
+String _$simpleSavedSearchesHash() =>
+    r'786e6c5255d6167b499775e66d521a9fee8beb3a';
 
-/// See also [homepageFilters].
-@ProviderFor(homepageFilters)
-final homepageFiltersProvider =
-    AutoDisposeFutureProvider<List<LensItem>>.internal(
-  homepageFilters,
-  name: r'homepageFiltersProvider',
+/// See also [SimpleSavedSearches].
+@ProviderFor(SimpleSavedSearches)
+final simpleSavedSearchesProvider = AutoDisposeAsyncNotifierProvider<
+    SimpleSavedSearches, List<String>>.internal(
+  SimpleSavedSearches.new,
+  name: r'simpleSavedSearchesProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$homepageFiltersHash,
+      : _$simpleSavedSearchesHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-typedef HomepageFiltersRef = AutoDisposeFutureProviderRef<List<LensItem>>;
+typedef _$SimpleSavedSearches = AutoDisposeAsyncNotifier<List<String>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
### Goal
Create a rough initial version of the custom lens experience, to use as an aid in polishing the design.

### Changes
- `WhatToTest.en-US.txt`: Update build notes.
- `clear_saved_searches_cell.dart`: Create a "Clear All Saved Searches" button that appears in settings, and the confirmation that shows when saved searches are cleared or when there are no saved searches to clear.
- `search_text_field.dart`: Update to include a button to save the search.  The button appears conditionally when there are more than three search results.
- `filters_enum.dart`: Update to include a `saved_search` (custom) case in the filter enum, and to use a wrapper that allows us to distinguish between a standard lens and a special-case custom lens.
- `filters_enum_extensions.dart`: Similar to above!
- `browse_saved_search_page.dart`: Create the version of `BrowsePage` to be used for custom lenses (with a very similar structure to all the other pages).
- `settings_page.dart`: Update to include a "Dev Settings" section.
- `homepage_filters_provider.dart`: Update to use the new wrapper instead of directly using the filter enum. 
- `simple_saved_searches_provider.dart`: Create; add all of the logic behind adding, removing, and deleting saved searches.

### Screenshots + Recordings

https://github.com/user-attachments/assets/7194b162-e72b-43cb-bbce-41038d96fa66



