### PR TITLE
Initial long-press context menu

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -253,13 +253,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -289,13 +285,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,1 +1,2 @@
-Rough initial version of the custom lens experience for design iteration.
+First step toward the long-press proof of concept.
+No differentiation between different browse modes, no animation, no shadow effect, etc.

--- a/lib/components/flash_animation.dart
+++ b/lib/components/flash_animation.dart
@@ -75,7 +75,7 @@ class FlashAnimationState extends State<FlashAnimation>
                     color: Theme.of(context)
                         .colorScheme
                         .secondaryContainer
-                        .withOpacity(_animation.value),
+                        .withValues(alpha: _animation.value),
                   )
                 : const SizedBox.shrink();
           },

--- a/lib/components/ping_cell.dart
+++ b/lib/components/ping_cell.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/components/ping_background.dart';
+import 'package:practice/components/ping_context_menu.dart';
 import 'package:practice/components/system_tap.dart';
 import 'package:practice/constants.dart';
 import 'package:practice/data/ping_data.dart';
@@ -24,6 +25,28 @@ class PingCell extends ConsumerWidget {
   final PingData inputPing;
   final bool tappable;
   final bool border;
+
+  void _showContextMenu(BuildContext context) {
+    
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierColor: Colors.transparent,
+      useSafeArea: false,
+      builder: (BuildContext context) {
+        return GestureDetector(
+          onTap: () => Navigator.of(context).pop(),
+          child: PingContextMenu(
+            pingData: inputPing,
+            border: border,
+          ),
+        );
+      },
+    );
+
+    HapticFeedback.mediumImpact();
+
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -76,25 +99,7 @@ class PingCell extends ConsumerWidget {
                               ])),
                     ),
                   ]))),
-          onLongPress: () {
-            Clipboard.setData(ClipboardData(text: inputPing.text));
-
-            // Show toast message
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                elevation: 0,
-                content: Text(
-                  'Copied to clipboard',
-                  style:
-                      TextStyle(color: Theme.of(context).colorScheme.onSurface),
-                ),
-                backgroundColor:
-                    Theme.of(context).colorScheme.secondaryContainer,
-                duration: Duration(seconds: 1),
-                behavior: SnackBarBehavior.floating,
-              ),
-            );
-          },
+          onLongPress: () => _showContextMenu(context),
           onTap: tappable
               ? () => Navigator.push(
                     context,

--- a/lib/components/ping_context_menu.dart
+++ b/lib/components/ping_context_menu.dart
@@ -1,0 +1,146 @@
+import 'dart:ui';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/components/ping_background.dart';
+import 'package:practice/constants.dart';
+import 'package:practice/data/ping_data.dart';
+import 'package:practice/design_system/system_text.dart';
+import 'package:practice/enums/font_enum.dart';
+import 'package:practice/enums/text_size_enum.dart';
+import 'package:practice/extensions/font_enum_extensions.dart';
+import 'package:practice/extensions/text_size_enum_extensions.dart';
+import 'package:practice/providers/ping_provider.dart';
+
+class PingContextMenu extends ConsumerWidget {
+  const PingContextMenu({
+    super.key,
+    required this.pingData,
+    required this.border,
+  });
+
+  final PingData pingData;
+  final bool border;
+
+  void _copyToClipboard(BuildContext context) {
+    Clipboard.setData(ClipboardData(text: pingData.text));
+    
+    Navigator.of(context).pop();
+    
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        elevation: 0,
+        content: Text(
+          'Ping copied',
+          style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        duration: Duration(seconds: 1),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Material(
+      color: Colors.transparent,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+        child: Container(
+          width: MediaQuery.of(context).size.width,
+          height: MediaQuery.of(context).size.height,
+          color: Color.fromRGBO(217, 217, 217, 0.20),
+          child: Column(
+            children: [
+              Spacer(flex: 2),
+              Column(
+                children: [
+                  Container(
+                    width: MediaQuery.of(context).size.width * 0.61,
+                    height: MediaQuery.of(context).size.width * 0.61,
+                    child: PingBackground(
+                      border: border,
+                      hidden: ref.watch(pingProvider(pingData).select((p) => p.hidden)),
+                      time: ref.watch(pingProvider(pingData).select((p) => p.resonantTime)),
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                            horizontal: spacingFour, vertical: spacingFour),
+                        child: Column(mainAxisSize: MainAxisSize.min, children: [
+                          AspectRatio(
+                            aspectRatio: 1,
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                  left: spacingXSmall,
+                                  right: spacingXSmall,
+                                  top: spacingXSmall),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Expanded(
+                                    child: AutoSizeText(
+                                      minFontSize: 1,
+                                      pingData.text,
+                                      style: TextStyle(
+                                        fontSize: TextSizeEnum.twentyNine.toFontSize(),
+                                        fontFamily: FontEnum.garamond.toFontFamily(),
+                                      ),
+                                    ),
+                                  ),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Padding(
+                                        padding: EdgeInsets.only(
+                                            top: spacingXSmall, bottom: 4),
+                                        child: SystemText(
+                                          align: TextAlign.center,
+                                          text: pingData.id!.toString(),
+                                          color: Theme.of(context).colorScheme.secondary,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]),
+                      ),
+                    ),
+                  ),
+                  
+                  SizedBox(height: spacingSmall),
+                  
+                  GestureDetector(
+                    onTap: () => _copyToClipboard(context),
+                    child: Container(
+                      padding: EdgeInsets.all(spacingSmall),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.copy,
+                            size: 24,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                          SizedBox(height: 4),
+                          SystemText(
+                            text: 'copy',
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Spacer(flex: 3),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "74273591bd8b7f82eeb1f191c1b65a6576535bbfd5ca3722778b07d5702d33cc"
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   build_config:
     dependency: transitive
     description:
@@ -101,26 +101,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: badce70566085f2e87434531c4a6bc8e833672f755fc51146d612245947e91c9
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b9070a4127033777c0e63195f6f117ed16a351ed676f6313b095cf4f328c0b82
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "1cdfece3eeb3f1263f7dbf5bcc0cba697bd0c22d2c866cb4b578c954dbb09bcf"
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.1"
+    version: "9.1.2"
   built_collection:
     dependency: transitive
     description:


### PR DESCRIPTION
### Goal
First step toward the long-press proof of concept. No differentiation between different browse modes, no animation, no shadow effect, etc.

### Changes
- _`project.pbxproj`: Clean file._
- _`WhatToTest.en-US.txt`: Update build notes._
- _`flash_animation.dart`: Update deprecated code._
- `ping_cell.dart`: Update function called upon long-press.
- `ping_context_menu.dart`: Create context menu, currently only containing the copy action.
- _`pubspec.lock`: Dependency updates._

### Screenshots + Recordings

https://github.com/user-attachments/assets/7abdcf1a-6918-46ec-9416-e1e84abce582


