### PR TITLE
Explore circular gesture recognizer

### DIFF
--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,2 +1,1 @@
-First step toward the long-press proof of concept.
-No differentiation between different browse modes, no animation, no shadow effect, etc.
+Exploring a circular gesture recognizer for switching between `grid` and `focus` views. You can toggle between old and new versions in the Settings menu!

--- a/lib/components/circular_gesture_detector.dart
+++ b/lib/components/circular_gesture_detector.dart
@@ -1,0 +1,90 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+class CircularGestureDetector extends StatefulWidget {
+  final Widget child;
+  final Function(double angle) onAngleUpdate;
+  
+  const CircularGestureDetector({
+    Key? key, 
+    required this.child,
+    required this.onAngleUpdate,
+  }) : super(key: key);
+
+  @override
+  _CircularGestureDetectorState createState() => _CircularGestureDetectorState();
+}
+
+class _CircularGestureDetectorState extends State<CircularGestureDetector> {
+  Offset _center = Offset.zero;
+  Offset? _previousPosition;
+  Offset? _startPosition;
+  bool _isHorizontalSwipe = false;
+  
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onPanStart: (details) {
+        final RenderBox box = context.findRenderObject() as RenderBox;
+        _center = box.size.center(box.localToGlobal(Offset.zero));
+        _previousPosition = details.globalPosition;
+        _startPosition = details.globalPosition;
+        _isHorizontalSwipe = false;
+      },
+      onPanUpdate: (details) {
+        if (_previousPosition == null || _startPosition == null) return;
+        
+        final currentPosition = details.globalPosition;
+        final deltaX = currentPosition.dx - _startPosition!.dx;
+        final deltaY = currentPosition.dy - _startPosition!.dy;
+                
+        if (!_isHorizontalSwipe && deltaX.abs() > 8 && deltaY.abs() < 30) {
+          _isHorizontalSwipe = true;
+          if (deltaX > 0) {
+            widget.onAngleUpdate(10);
+          } else {
+            widget.onAngleUpdate(-10);
+          }
+          return;
+        }
+        
+        // If we've already detected a horizontal swipe, we can ignore further angle updates! (prevents skipping)
+        if (_isHorizontalSwipe) {
+          return;
+        }
+        
+        final previousAngle = _getAngle(_center, _previousPosition!);
+        final currentAngle = _getAngle(_center, currentPosition);
+        
+        var angleDiff = currentAngle - previousAngle;
+                
+        if (angleDiff > 180) {
+          angleDiff -= 360;
+        } else if (angleDiff < -180) {
+          angleDiff += 360;
+        }
+        
+        if (angleDiff.abs() > 2) {
+          widget.onAngleUpdate(angleDiff);
+        }
+        
+        _previousPosition = currentPosition;
+      },
+      onPanEnd: (details) {
+        _previousPosition = null;
+        _startPosition = null;
+        _isHorizontalSwipe = false;
+      },
+      child: widget.child,
+    );
+  }
+  
+  double _getAngle(Offset center, Offset position) {
+    final deltaX = position.dx - center.dx;
+    final deltaY = position.dy - center.dy;
+    
+    final radians = math.atan2(deltaY, deltaX);
+    return (radians * 180 / math.pi + 360) % 360;
+  }
+}

--- a/lib/components/gesture_detector_toggle.dart
+++ b/lib/components/gesture_detector_toggle.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:practice/components/settings_activation_cell.dart';
+
+class CircularGestureActivationCell extends StatefulWidget {
+  const CircularGestureActivationCell({super.key});
+
+  @override
+  _CircularGestureActivationCellState createState() => _CircularGestureActivationCellState();
+}
+
+class _CircularGestureActivationCellState extends State<CircularGestureActivationCell> {
+  bool _isEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSetting();
+  }
+
+  _loadSetting() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _isEnabled = prefs.getBool('circular_gesture_enabled') ?? false;
+    });
+  }
+
+  _saveSetting(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('circular_gesture_enabled', value);
+    setState(() {
+      _isEnabled = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsActivationCell(
+      text: _isEnabled ? 'Switch back to horizontal swipes' : 'Try out circular gesture recognizer',
+      onTap: () {
+        _saveSetting(!_isEnabled);
+      },
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/components/circular_gesture_detector.dart';
 import 'package:practice/components/dial.dart';
 import 'package:practice/components/fade.dart';
 import 'package:practice/components/system_tap.dart';
@@ -14,6 +15,7 @@ import 'package:practice/pages/settings_page.dart';
 import 'package:practice/providers/browse_temp_provider.dart';
 import 'package:practice/providers/local_backup_on_provider.dart';
 import 'package:practice/utils/backup_utils.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -24,10 +26,13 @@ class HomePage extends ConsumerStatefulWidget {
 
 class _ExplorePageState extends ConsumerState<HomePage>
     with WidgetsBindingObserver {
+  bool _useCircularGesture = false;
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _loadGestureSetting();
   }
 
   @override
@@ -36,10 +41,22 @@ class _ExplorePageState extends ConsumerState<HomePage>
     super.dispose();
   }
 
+  _loadGestureSetting() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _useCircularGesture = prefs.getBool('circular_gesture_enabled') ?? false;
+    });
+  }
+
+  void _onNavigationReturn() {
+    _loadGestureSetting();
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
+        _loadGestureSetting();
         break;
       case AppLifecycleState.inactive:
         if (ref.read(localBackupOnProvider)) BackupUtils.backupPings();
@@ -53,88 +70,130 @@ class _ExplorePageState extends ConsumerState<HomePage>
     }
   }
 
+  Widget _buildBottomNavigation() {
+    final bottomNav = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Fade(),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            SystemTap(
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => SearchPage()),
+              ),
+              child: SizedBox(
+                height: tapTarget,
+                width: tapTarget,
+                child: Center(
+                  child: Icon(
+                    PhosphorIcons.magnifying_glass,
+                    size: 34,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+            SystemTap(
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => NewPingPage()),
+              ),
+              child: Icon(
+                PhosphorIcons.circle_fill,
+                size: pingButtonSize,
+                color: _useCircularGesture ? Theme.of(context).colorScheme.error : Theme.of(context).colorScheme.primary,
+              ),
+            ),
+            SystemTap(
+              onTap: () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => SettingsPage()),
+                );
+                _onNavigationReturn();
+              },
+              child: SizedBox(
+                height: tapTarget,
+                width: tapTarget,
+                child: Center(
+                  child: Icon(
+                    PhosphorIcons.gear,
+                    size: 34,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    if (_useCircularGesture) {
+      return CircularGestureDetector(
+        onAngleUpdate: (angleDiff) {
+          final browseNotifier = ref.read(browseTempProvider.notifier);
+          final currentMode = ref.read(browseTempProvider);
+
+          if (angleDiff > 0 &&
+              (currentMode == null || currentMode == BrowseEnum.grid)) {
+            HapticFeedback.lightImpact();
+            browseNotifier.setMode(BrowseEnum.focus);
+          }
+          else if (angleDiff < 0 &&
+              (currentMode == null || currentMode == BrowseEnum.focus)) {
+            HapticFeedback.lightImpact();
+            browseNotifier.setMode(BrowseEnum.grid);
+          }
+        },
+        child: bottomNav,
+      );
+    } else {
+      return GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragUpdate: (details) {
+          if (details.primaryDelta != null &&
+              details.primaryDelta!.abs() > 8) {
+            final browseNotifier = ref.read(browseTempProvider.notifier);
+            final currentMode = ref.read(browseTempProvider);
+
+            if (details.primaryDelta! > 0 &&
+                (currentMode == null || currentMode == BrowseEnum.grid)) {
+              HapticFeedback.lightImpact();
+              browseNotifier.setMode(BrowseEnum.focus);
+            } else if (details.primaryDelta! < 0 &&
+                (currentMode == null || currentMode == BrowseEnum.focus)) {
+              HapticFeedback.lightImpact();
+              browseNotifier.setMode(BrowseEnum.grid);
+            }
+          }
+        },
+        child: bottomNav,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: SafeArea(
-      child: Stack(children: [
-        Padding(
-            padding: EdgeInsets.only(bottom: pingButtonSize),
-            child: HomePageExplore()),
-        Align(
-            alignment: Alignment.bottomCenter,
-            child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onHorizontalDragUpdate: (details) {
-                  if (details.primaryDelta != null &&
-                      details.primaryDelta!.abs() > 8) {
-                    final browseNotifier =
-                        ref.read(browseTempProvider.notifier);
-                    final currentMode = ref.read(browseTempProvider);
-
-                    if (details.primaryDelta! > 0 &&
-                        (currentMode == null ||
-                            currentMode == BrowseEnum.grid)) {
-                      HapticFeedback.lightImpact();
-                      browseNotifier.setMode(BrowseEnum.focus);
-                    } else if (details.primaryDelta! < 0 &&
-                        (currentMode == null ||
-                            currentMode == BrowseEnum.focus)) {
-                      HapticFeedback.lightImpact();
-                      browseNotifier.setMode(BrowseEnum.grid);
-                    }
-                  }
-                },
-                child: Column(mainAxisSize: MainAxisSize.min, children: [
-                  Fade(),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      SystemTap(
-                          onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => SearchPage()),
-                              ),
-                          child: SizedBox(
-                              height: tapTarget,
-                              width: tapTarget,
-                              child: Center(
-                                  child: Icon(PhosphorIcons.magnifying_glass,
-                                      size: 34,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .primary)))),
-                      SystemTap(
-                          onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => NewPingPage()),
-                              ),
-                          child: Icon(PhosphorIcons.circle_fill,
-                              size: pingButtonSize,
-                              color: Theme.of(context).colorScheme.primary)),
-                      SystemTap(
-                          onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => SettingsPage()),
-                              ),
-                          child: SizedBox(
-                              height: tapTarget,
-                              width: tapTarget,
-                              child: Center(
-                                  child: Icon(PhosphorIcons.gear,
-                                      size: 34,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .primary)))),
-                    ],
-                  )
-                ]))),
-        Dial()
-      ]),
-    ));
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(bottom: pingButtonSize),
+              child: HomePageExplore(),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: _buildBottomNavigation(),
+            ),
+            Dial()
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/components/browse_activation_cell.dart';
+import 'package:practice/components/gesture_detector_toggle.dart';
 import 'package:practice/components/cloud_backup_activation_cell.dart';
 import 'package:practice/components/clear_saved_searches_cell.dart';
 import 'package:practice/components/import_pings_button.dart';
@@ -36,6 +37,7 @@ class SettingsPage extends ConsumerWidget {
                       children: [
                         NavCellCluster(text: 'Dev Settings', children: [
                           ClearSavedSearchesCell(),
+                          CircularGestureActivationCell(),
                         ]),
                         SizedBox(
                           height: spacingMedium,


### PR DESCRIPTION
### Goal
Recognize swipes _around_ the ping button to switch between `grid` and `focus` views.  Currently, only strictly horizontal swipes are recognized; this PR adds an exploratory option to use a circular gesture recognizer instead, which should pick up on swipes that follow the curve of the circular button.

### Changes
- _`WhatToTest.en-US.txt`: Update build notes._
- `circular_gesture_detector.dart`: Create the new gesture recognizer.
- `gesture_detector_toggle.dart`: Create the Dev Settings button to toggle between old and new experiences.
- `home_page.dart`: Update to conditionally use the correct gesture recognizer, depending on setting.
- `settings_page.dart`: Update to include gesture detector toggle.

### Screenshots + Recordings

https://github.com/user-attachments/assets/8ed5af4f-87d4-4b72-9d96-bcf81d8cbbd9

