### PR TITLE
Implement cached search provider to reduce flickering

### DIFF
--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,1 +1,1 @@
-Added option in Dev Settings to hide/view focus action buttons; integrated circular gesture recognizer.
+Check out Dev Settings for a cached search provider (to reduce flickering when typing in search bar).

--- a/lib/components/cached_search_toggle.dart
+++ b/lib/components/cached_search_toggle.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/components/settings_activation_cell.dart';
+import 'package:practice/providers/cached_search_setting_provider.dart';
+
+class CachedSearchToggleCell extends ConsumerWidget {
+  const CachedSearchToggleCell({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isEnabled = ref.watch(cachedSearchSettingProvider);
+    
+    return SettingsActivationCell(
+      text: isEnabled 
+        ? 'Switch back to old search provider' 
+        : 'Try out new cached search provider',
+      onTap: () {
+        ref.read(cachedSearchSettingProvider.notifier).toggle();
+      },
+    );
+  }
+}

--- a/lib/components/ping_search_list.dart
+++ b/lib/components/ping_search_list.dart
@@ -3,13 +3,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/components/ping_grid.dart';
 import 'package:practice/design_system/system_text.dart';
 import 'package:practice/providers/search_provider.dart';
+import 'package:practice/providers/cached_search_provider.dart';
+import 'package:practice/providers/cached_search_setting_provider.dart';
 
 class PingSearchList extends ConsumerWidget {
   const PingSearchList({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final pings = ref.watch(searchProvider);
+    final useCachedSearch = ref.watch(cachedSearchSettingProvider);
+    
+    final pings = useCachedSearch 
+      ? ref.watch(cachedSearchProvider)
+      : ref.watch(searchProvider);
 
     return switch (pings) {
       AsyncData(value: final pingsValue) => PingGrid(pings: pingsValue, shouldRetainScrollPosition: true),

--- a/lib/components/search_text_field.dart
+++ b/lib/components/search_text_field.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/constants.dart';
 import 'package:practice/providers/search_string_provider.dart';
 import 'package:practice/providers/search_provider.dart';
+import 'package:practice/providers/cached_search_provider.dart';
+import 'package:practice/providers/cached_search_setting_provider.dart';
 import 'package:practice/providers/simple_saved_searches_provider.dart';
 
 class SearchTextField extends ConsumerStatefulWidget {
@@ -57,7 +59,11 @@ class _PingEntryState extends ConsumerState<SearchTextField> {
   @override
   Widget build(BuildContext context) {
     final searchString = ref.watch(searchStringProvider);
-    final searchResults = ref.watch(searchProvider);
+    final useCachedSearch = ref.watch(cachedSearchSettingProvider);
+    
+    final searchResults = useCachedSearch 
+      ? ref.watch(cachedSearchProvider)
+      : ref.watch(searchProvider);
     
     final showPlusButton = searchResults.when(
       data: (pings) => pings.length > 3,
@@ -89,6 +95,11 @@ class _PingEntryState extends ConsumerState<SearchTextField> {
                       onPressed: () {
                         HapticFeedback.selectionClick();
                         ref.read(searchStringProvider.notifier).setSearch('');
+                        
+                        if (useCachedSearch) {
+                          ref.read(cachedSearchProvider.notifier).search('');
+                        }
+                        
                         controller.clear();
                         focusNode.requestFocus();
                       },
@@ -100,8 +111,13 @@ class _PingEntryState extends ConsumerState<SearchTextField> {
                 borderSide: BorderSide.none,
               ),
             ),
-            onChanged: (value) =>
-                ref.read(searchStringProvider.notifier).setSearch(value),
+            onChanged: (value) {
+              ref.read(searchStringProvider.notifier).setSearch(value);
+              
+              if (useCachedSearch) {
+                ref.read(cachedSearchProvider.notifier).search(value);
+              }
+            },
           ),
         ),
         if (showPlusButton) ...[

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:practice/components/browse_activation_cell.dart';
 import 'package:practice/components/focus_buttons_settings_cell.dart';
+import 'package:practice/components/cached_search_toggle.dart';
 import 'package:practice/components/cloud_backup_activation_cell.dart';
 import 'package:practice/components/clear_saved_searches_cell.dart';
 import 'package:practice/components/import_pings_button.dart';
@@ -38,6 +39,7 @@ class SettingsPage extends ConsumerWidget {
                         NavCellCluster(text: 'Dev Settings', children: [
                           ClearSavedSearchesCell(),
                           HideFocusButtonsSettingCell(),
+                          CachedSearchToggleCell()
                         ]),
                         SizedBox(
                           height: spacingMedium,

--- a/lib/providers/cached_search_provider.dart
+++ b/lib/providers/cached_search_provider.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:collection/collection.dart';
+import 'package:practice/data/ping_data.dart';
+import 'package:practice/providers/pings_map_provider.dart';
+import 'dart:async';
+
+class CachedSearchNotifier extends AsyncNotifier<List<PingData>> {
+  Timer? _debounceTimer;
+  String _currentQuery = '';
+  final Map<String, List<PingData>> _cache = {};
+
+  @override
+  Future<List<PingData>> build() async {
+    ref.onDispose(() {
+      _debounceTimer?.cancel();
+    });
+    
+    return [];
+  }
+
+  void search(String query) {
+    _debounceTimer?.cancel();
+    
+    if (query.trim().isEmpty) {
+      _currentQuery = '';
+      state = const AsyncValue.data([]);
+      return;
+    }
+
+    if (_cache.containsKey(query)) {
+      final cachedResults = _cache[query]!;
+      if (!_areResultsEqual(state.valueOrNull ?? [], cachedResults)) {
+        state = AsyncValue.data(cachedResults);
+      }
+      _currentQuery = query;
+      return;
+    }
+
+    _debounceTimer = Timer(const Duration(milliseconds: 0), () async {
+      if (query == _currentQuery) return;
+      
+      _currentQuery = query;
+      
+      if (state.valueOrNull == null || state.valueOrNull!.isEmpty) {
+        state = const AsyncValue.loading();
+      }
+      
+      try {
+        final results = await performSearch(query);
+        
+        if (query == _currentQuery) {
+          _cache[query] = results;
+          
+          if (!_areResultsEqual(state.valueOrNull ?? [], results)) {
+            state = AsyncValue.data(results);
+          }
+        }
+      } catch (error, stackTrace) {
+        if (query == _currentQuery) {
+          state = AsyncValue.error(error, stackTrace);
+        }
+      }
+    });
+  }
+
+  bool _areResultsEqual(List<PingData> list1, List<PingData> list2) {
+    if (list1.length != list2.length) return false;
+    
+    return const ListEquality().equals(list1, list2);
+  }
+
+  Future<List<PingData>> performSearch(String searchString) async {
+    return ref.read(pingsMapProvider).when(
+      data: (map) {
+        final visiblePings = map.values.where((ping) => !ping.hidden);
+        return visiblePings
+            .where((ping) =>
+                ping.text.toLowerCase().contains(searchString.toLowerCase()))
+            .toList()
+          ..sort((a, b) => b.time.compareTo(a.time));
+      },
+      loading: () => <PingData>[],
+      error: (_, __) => <PingData>[],
+    );
+  }
+
+  void clearCache() {
+    _cache.clear();
+  }
+}
+
+final cachedSearchProvider = AsyncNotifierProvider<CachedSearchNotifier, List<PingData>>(
+  () => CachedSearchNotifier(),
+);

--- a/lib/providers/cached_search_setting_provider.dart
+++ b/lib/providers/cached_search_setting_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CachedSearchSettingNotifier extends StateNotifier<bool> {
+  CachedSearchSettingNotifier() : super(false) {
+    _loadSetting();
+  }
+
+  Future<void> _loadSetting() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool('cached_search_enabled') ?? false;
+  }
+
+  Future<void> setSetting(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('cached_search_enabled', value);
+    state = value;
+  }
+
+  Future<void> toggle() async {
+    await setSetting(!state);
+  }
+}
+
+final cachedSearchSettingProvider = StateNotifierProvider<CachedSearchSettingNotifier, bool>(
+  (ref) => CachedSearchSettingNotifier(),
+);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,7 +186,7 @@ packages:
     source: hosted
     version: "4.10.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   url_launcher: ^6.3.1
   posthog_flutter: ^4.0.1
   share_plus: ^7.2.2
+  collection: ^1.17.2
 
 dependency_overrides:
   intl: ^0.20.2


### PR DESCRIPTION
### Goal
Prevent flickering while typing search term in ping search bar by caching the search results and only updating the results when there are actually new/different results to be shown. (Poor description, but check out the demo recordings!)

### Changes
- _`WhatToTest.en-US.txt`: Update build notes._
- `cached_search_toggle.dart`: Add old/new settings toggle component.
- `ping_search_list.dart`: Add check to switch between old/new search provider.
- `search_text_field.dart`: Add check to switch between old/new search provider.
- `settings_page.dart`: Update settings page to include toggle.
- `cached_search_provider.dart`: The body of the cached search code.
- `cached_search_setting_provider.dart`: Provider to communicate the old/new search provider setting to the rest of app.
- _`pubspec.lock`: New dependency specification._
- _`pubspec.yaml`: New dependecy specification._

### Screen Recordings
| Old version | New version |
|-----|-----|
| <video src="https://github.com/user-attachments/assets/1cdad97d-0e7d-464b-b439-f109b748bb80" controls width="300"></video> | <video src="https://github.com/user-attachments/assets/96bd25df-68f2-422e-a059-3687cd9c4388" controls width="300"></video> |