### PR TITLE
Add back arrow to traversal pages

### DIFF
--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,1 +1,1 @@
-Remove leading spaces from export text; add haptics to "create lens" button.
+Add back arrow to “secret” lenses view!  Traversal pages!

--- a/lib/pages/explore_page.dart
+++ b/lib/pages/explore_page.dart
@@ -7,22 +7,58 @@ import 'package:practice/extensions/font_enum_extensions.dart';
 import 'package:practice/extensions/text_size_enum_extensions.dart';
 
 class ExplorePage extends StatelessWidget {
-  const ExplorePage(
-      {super.key,
-      required this.tabController,
-      required this.tabs,
-      required this.children});
+  const ExplorePage({
+    super.key,
+    required this.tabController,
+    required this.tabs,
+    required this.children,
+    this.leading
+  });
 
   final TabController tabController;
   final List<String> tabs;
   final List<Widget> children;
+  final Widget? leading;
 
   Widget build(BuildContext context) {
     return Column(children: [
       Container(
-          padding: EdgeInsets.only(top: spacingSmall),
-          child: TabBar(
-              padding: EdgeInsets.only(right: spacingMedium, left: 0),
+        padding: EdgeInsets.only(top: spacingSmall),
+        child: leading != null 
+          ? Row(
+              children: [
+                leading!,
+                Expanded(
+                  child: TabBar(
+                    tabAlignment: TabAlignment.start,
+                    controller: tabController,
+                    isScrollable: true,
+                    splashFactory: NoSplash.splashFactory,
+                    dividerColor: Colors.transparent,
+                    labelColor: Theme.of(context).colorScheme.primary,
+                    unselectedLabelColor: Theme.of(context).colorScheme.secondary,
+                    indicator: UnderlineTabIndicator(
+                      borderSide: BorderSide(
+                        width: 2.0,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    onTap: (value) {},
+                    tabs: tabs.map((tab) {
+                      return Text(
+                        tab,
+                        style: TextStyle(
+                          fontSize: TextSizeEnum.twentyNine.toFontSize(),
+                          fontFamily: FontEnum.sfpro.toFontFamily(),
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            )
+          : TabBar(
+              padding: EdgeInsets.only(right: spacingMedium, left: spacingMedium),
               controller: tabController,
               isScrollable: true,
               splashFactory: NoSplash.splashFactory,
@@ -43,14 +79,17 @@ class ExplorePage extends StatelessWidget {
                       fontSize: TextSizeEnum.twentyNine.toFontSize(),
                       fontFamily: FontEnum.sfpro.toFontFamily()),
                 );
-              }).toList())),
+              }).toList(),
+            ),
+      ),
       Expanded(
-          child: Stack(
-        children: [
-          TabBarView(controller: tabController, children: children),
-          Align(alignment: Alignment.topCenter, child: Fade(topDown: true)),
-        ],
-      ))
+        child: Stack(
+          children: [
+            TabBarView(controller: tabController, children: children),
+            Align(alignment: Alignment.topCenter, child: Fade(topDown: true)),
+          ],
+        ),
+      )
     ]);
   }
 }

--- a/lib/pages/explore_page.dart
+++ b/lib/pages/explore_page.dart
@@ -12,22 +12,22 @@ class ExplorePage extends StatelessWidget {
     required this.tabController,
     required this.tabs,
     required this.children,
-    this.leading
+    this.backArrow
   });
 
   final TabController tabController;
   final List<String> tabs;
   final List<Widget> children;
-  final Widget? leading;
+  final Widget? backArrow;
 
   Widget build(BuildContext context) {
     return Column(children: [
       Container(
         padding: EdgeInsets.only(top: spacingSmall),
-        child: leading != null 
+        child: backArrow != null 
           ? Row(
               children: [
-                leading!,
+                backArrow!,
                 Expanded(
                   child: TabBar(
                     tabAlignment: TabAlignment.start,

--- a/lib/pages/traversal/traversal_day_of_month_page.dart
+++ b/lib/pages/traversal/traversal_day_of_month_page.dart
@@ -76,7 +76,7 @@ class _TraversalDayOfMonthState extends ConsumerState<TraversalDayOfMonthPage>
       child: DefaultTabController(
         length: daysOfMonth.length,
         child: ExplorePage(
-          leading: SystemButton(
+          backArrow: SystemButton(
             onTap: () => Navigator.pop(context),
             icon: PhosphorIcons.caret_left,
           ),

--- a/lib/pages/traversal/traversal_day_of_month_page.dart
+++ b/lib/pages/traversal/traversal_day_of_month_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/design_system/system_button.dart';
 import 'package:practice/enums/time_filter_enum.dart';
 import 'package:practice/pages/browse_time_page.dart';
 import 'package:practice/pages/explore_page.dart';
@@ -74,6 +76,10 @@ class _TraversalDayOfMonthState extends ConsumerState<TraversalDayOfMonthPage>
       child: DefaultTabController(
         length: daysOfMonth.length,
         child: ExplorePage(
+          leading: SystemButton(
+            onTap: () => Navigator.pop(context),
+            icon: PhosphorIcons.caret_left,
+          ),
           tabController: _tabController,
           tabs: daysOfMonth.map((filter) {
             return filter.toString();

--- a/lib/pages/traversal/traversal_day_of_week_page.dart
+++ b/lib/pages/traversal/traversal_day_of_week_page.dart
@@ -44,7 +44,7 @@ class _TraversalDayOfWeekState extends ConsumerState<TraversalDayOfWeekPage>
       child: DefaultTabController(
         length: DateTime.daysPerWeek,
         child: ExplorePage(
-          leading: SystemButton(
+          backArrow: SystemButton(
             onTap: () => Navigator.pop(context),
             icon: PhosphorIcons.caret_left,
           ),

--- a/lib/pages/traversal/traversal_day_of_week_page.dart
+++ b/lib/pages/traversal/traversal_day_of_week_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/design_system/system_button.dart';
 import 'package:practice/enums/day_of_week_enum.dart';
 import 'package:practice/enums/time_filter_enum.dart';
 import 'package:practice/extensions/day_of_week_enum_extensions.dart';
@@ -42,6 +44,10 @@ class _TraversalDayOfWeekState extends ConsumerState<TraversalDayOfWeekPage>
       child: DefaultTabController(
         length: DateTime.daysPerWeek,
         child: ExplorePage(
+          leading: SystemButton(
+            onTap: () => Navigator.pop(context),
+            icon: PhosphorIcons.caret_left,
+          ),
           tabController: _tabController,
           tabs: DayOfWeekEnum.values.map((filter) {
             return filter.title();

--- a/lib/pages/traversal/traversal_mode_page.dart
+++ b/lib/pages/traversal/traversal_mode_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/design_system/system_button.dart';
 import 'package:practice/enums/theme_mode_enum.dart';
 import 'package:practice/extensions/theme_mode_enum_extensions.dart';
 import 'package:practice/pages/browse_mode_page.dart';
@@ -41,6 +43,10 @@ class _TraversalPageState extends ConsumerState<TraversalModePage>
       child: DefaultTabController(
         length: ThemeModeEnum.values.length,
         child: ExplorePage(
+          leading: SystemButton(
+            onTap: () => Navigator.pop(context),
+            icon: PhosphorIcons.caret_left,
+          ),
           tabController: _tabController,
           tabs: ThemeModeEnum.values.map((filter) {
             return filter.title();

--- a/lib/pages/traversal/traversal_mode_page.dart
+++ b/lib/pages/traversal/traversal_mode_page.dart
@@ -43,7 +43,7 @@ class _TraversalPageState extends ConsumerState<TraversalModePage>
       child: DefaultTabController(
         length: ThemeModeEnum.values.length,
         child: ExplorePage(
-          leading: SystemButton(
+          backArrow: SystemButton(
             onTap: () => Navigator.pop(context),
             icon: PhosphorIcons.caret_left,
           ),

--- a/lib/pages/traversal/traversal_month_page.dart
+++ b/lib/pages/traversal/traversal_month_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/design_system/system_button.dart';
 import 'package:practice/enums/month_enum.dart';
 import 'package:practice/enums/time_filter_enum.dart';
 import 'package:practice/extensions/month_enum_extensions.dart';
@@ -42,6 +44,10 @@ class _TraversalMonthState extends ConsumerState<TraversalMonthPage>
       child: DefaultTabController(
         length: DateTime.monthsPerYear,
         child: ExplorePage(
+          leading: SystemButton(
+            onTap: () => Navigator.pop(context),
+            icon: PhosphorIcons.caret_left,
+          ),
           tabController: _tabController,
           tabs: MonthEnum.values.map((filter) {
             return filter.title();

--- a/lib/pages/traversal/traversal_month_page.dart
+++ b/lib/pages/traversal/traversal_month_page.dart
@@ -44,7 +44,7 @@ class _TraversalMonthState extends ConsumerState<TraversalMonthPage>
       child: DefaultTabController(
         length: DateTime.monthsPerYear,
         child: ExplorePage(
-          leading: SystemButton(
+          backArrow: SystemButton(
             onTap: () => Navigator.pop(context),
             icon: PhosphorIcons.caret_left,
           ),

--- a/lib/pages/traversal/traversal_year_page.dart
+++ b/lib/pages/traversal/traversal_year_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phosphor_icons/flutter_phosphor_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:practice/design_system/system_button.dart';
 import 'package:practice/enums/time_filter_enum.dart';
 import 'package:practice/pages/browse_time_page.dart';
 import 'package:practice/pages/explore_page.dart';
@@ -59,6 +61,10 @@ class _TraversalYearState extends ConsumerState<TraversalYearPage>
       child: DefaultTabController(
         length: years.length,
         child: ExplorePage(
+          backArrow: SystemButton(
+            onTap: () => Navigator.pop(context),
+            icon: PhosphorIcons.caret_left,
+          ),
           tabController: _tabController,
           tabs: years.map((year) => year.toString()).toList(),
           children: years.map((year) {


### PR DESCRIPTION
### Goal
Add a back arrow to the traversal pages (reached by clicking metadata on a ping in detail view) to make navigation a bit more clear!

### Changes
- _`WhatToTest.en-US.txt`: Update build notes._
- `explore_page.dart`: Add an optional `backArrow` widget as a property of the `explorePage` object; if it exists, it's added to the upper left corner on each page, before the filters.  Otherwise, the filter region is left untouched entirely (to avoid some spacing weirdness for the home page).
- `traversal_...dart`: Pass a backArrow to be built when calling the creation of each traversal page.

### Screen Recording


https://github.com/user-attachments/assets/ee2f1805-0755-4e36-9a76-5258d4e57d75